### PR TITLE
metrics: is_firedancer label added to solana node version metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ The tables below describes all the metrics collected by the `solana-exporter`:
 | `solana_validator_block_size`                  | Number of transactions per block.                                                                                     | `nodekey`, `transaction_type` |
 | `solana_node_block_height`                     | The current block height of the node.                                                                                 | N/A                           |
 | `solana_node_is_active`                        | Whether the node is active and participating in consensus.                                                            | `identity`                    |
+| `solana_foundation_min_required_version` | Minimum required Solana version for the [solana foundation delegation program](https://solana.org/delegation-program) | `version`, `cluster`
 
 #### Vote Account Metrics
 
@@ -174,3 +175,4 @@ The table below describes the various metric labels:
 | `status`           | Whether a slot was skipped or valid.          | `valid`, `skipped`                                   |
 | `epoch`            | Solana epoch number.                          | e.g., `663`                                          |
 | `transaction_type` | General transaction type.                     | `vote`, `non_vote`                                   |
+| `cluster`          | Solana cluster.                                | `mainnet-beta`, `devnet`, `testnet`                 |

--- a/README.md
+++ b/README.md
@@ -147,7 +147,8 @@ The tables below describes all the metrics collected by the `solana-exporter`:
 | `solana_validator_block_size`                  | Number of transactions per block.                                                                                     | `nodekey`, `transaction_type` |
 | `solana_node_block_height`                     | The current block height of the node.                                                                                 | N/A                           |
 | `solana_node_is_active`                        | Whether the node is active and participating in consensus.                                                            | `identity`                    |
-| `solana_foundation_min_required_version` | Minimum required Solana version for the [solana foundation delegation program](https://solana.org/delegation-program) | `version`, `cluster`
+| `solana_node_is_outdated`                      | Whether the node is running a version below the required minimum for Firedancer and Agave clients.                                      | `is_firedancer`, `version`, `required_version`, `cluster` |
+| `solana_foundation_min_required_version` | Minimum required Solana version for the [solana foundation delegation program](https://solana.org/delegation-program) | `agave_min_version`, `firedancer_min_version`, `cluster`, `epoch` |
 
 #### Vote Account Metrics
 
@@ -176,3 +177,5 @@ The table below describes the various metric labels:
 | `epoch`            | Solana epoch number.                          | e.g., `663`                                          |
 | `transaction_type` | General transaction type.                     | `vote`, `non_vote`                                   |
 | `cluster`          | Solana cluster.                                | `mainnet-beta`, `devnet`, `testnet`                 |
+| `is_firedancer`    | Whether the node is running Firedancer.        | `0`, `1`                                            |
+| `required_version` | Minimum required version for the node type.    | e.g., `1.0.0`                                       |

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ The tables below describes all the metrics collected by the `solana-exporter`:
 | `solana_node_block_height`                     | The current block height of the node.                                                                                 | N/A                           |
 | `solana_node_is_active`                        | Whether the node is active and participating in consensus.                                                            | `identity`                    |
 | `solana_node_is_outdated`                      | Whether the node is running a version below the required minimum for Firedancer and Agave clients.                                      | `is_firedancer`, `version`, `required_version`, `cluster` |
+| `solana_node_needs_update`                     | Whether the node needs to be updated before the next epoch to remain compliant.                                                         | `is_firedancer`, `version`, `required_version`, `cluster`, `epoch` |
 | `solana_foundation_min_required_version` | Minimum required Solana version for the [solana foundation delegation program](https://solana.org/delegation-program) | `agave_min_version`, `firedancer_min_version`, `cluster`, `epoch` |
 
 #### Vote Account Metrics

--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ The exporter is configured via the following command line arguments:
 | `-rpc-url`                             | Solana RPC URL (including protocol and path), e.g., `"http://localhost:8899"` or `"https://api.mainnet-beta.solana.com"`                                                                                                | `"http://localhost:8899"` |
 | `-slot-pace`                           | This is the time (in seconds) between slot-watching metric collections                                                                                                                                                  | `1`                       |
 | `-active-identity`                     | Validator identity public key used to determine if the node is considered active in the `solana_node_is_active` metric.                                                                                                 | N/A                       |
-| `-epoch-cleanup-time`                  | The time to wait before cleaning old epoch metrics from the prometheus endpoint.                                                                                                                                        |                           |
+| `-epoch-cleanup-time`                  | The time to wait before cleaning old epoch metrics from the prometheus endpoint.                                                                                                                                        | `60`                      |
+| `-firedancer-metrics-port`             | Port number for Firedancer metrics endpoint.                                                                                                                                                                            | `7999`                    |
 
 ### Notes on Configuration
 

--- a/cmd/solana-exporter/collector.go
+++ b/cmd/solana-exporter/collector.go
@@ -67,10 +67,10 @@ type SolanaCollector struct {
 	isFiredancer bool
 }
 
-func NewSolanaCollector(rpcClient *rpc.Client, apiClient *api.Client, config *ExporterConfig) *SolanaCollector {
+func NewSolanaCollector(rpcClient *rpc.Client, config *ExporterConfig) *SolanaCollector {
 	collector := &SolanaCollector{
 		rpcClient: rpcClient,
-		apiClient: apiClient,
+		apiClient: api.NewClient(rpcClient),
 		logger:    slog.Get(),
 		config:    config,
 		ValidatorActiveStake: NewGaugeDesc(

--- a/cmd/solana-exporter/collector.go
+++ b/cmd/solana-exporter/collector.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/asymmetric-research/solana-exporter/pkg/api"
 	"github.com/asymmetric-research/solana-exporter/pkg/rpc"
 	"github.com/asymmetric-research/solana-exporter/pkg/slog"
 	"github.com/prometheus/client_golang/prometheus"
@@ -22,6 +23,7 @@ const (
 	EpochLabel           = "epoch"
 	TransactionTypeLabel = "transaction_type"
 	IsFiredancerLabel    = "is_firedancer"
+	ClusterLabel         = "cluster"
 
 	StatusSkipped = "skipped"
 	StatusValid   = "valid"
@@ -35,32 +37,35 @@ const (
 
 type SolanaCollector struct {
 	rpcClient *rpc.Client
+	apiClient *api.Client
 	logger    *zap.SugaredLogger
 
 	config *ExporterConfig
 
 	/// descriptors:
-	ValidatorActiveStake    *GaugeDesc
-	ClusterActiveStake      *GaugeDesc
-	ValidatorLastVote       *GaugeDesc
-	ClusterLastVote         *GaugeDesc
-	ValidatorRootSlot       *GaugeDesc
-	ClusterRootSlot         *GaugeDesc
-	ValidatorDelinquent     *GaugeDesc
-	ClusterValidatorCount   *GaugeDesc
-	AccountBalances         *GaugeDesc
-	NodeVersion             *GaugeDesc
-	NodeIsHealthy           *GaugeDesc
-	NodeNumSlotsBehind      *GaugeDesc
-	NodeMinimumLedgerSlot   *GaugeDesc
-	NodeFirstAvailableBlock *GaugeDesc
-	NodeIdentity            *GaugeDesc
-	NodeIsActive            *GaugeDesc
+	ValidatorActiveStake         *GaugeDesc
+	ClusterActiveStake           *GaugeDesc
+	ValidatorLastVote            *GaugeDesc
+	ClusterLastVote              *GaugeDesc
+	ValidatorRootSlot            *GaugeDesc
+	ClusterRootSlot              *GaugeDesc
+	ValidatorDelinquent          *GaugeDesc
+	ClusterValidatorCount        *GaugeDesc
+	AccountBalances              *GaugeDesc
+	NodeVersion                  *GaugeDesc
+	NodeIsHealthy                *GaugeDesc
+	NodeNumSlotsBehind           *GaugeDesc
+	NodeMinimumLedgerSlot        *GaugeDesc
+	NodeFirstAvailableBlock      *GaugeDesc
+	NodeIdentity                 *GaugeDesc
+	NodeIsActive                 *GaugeDesc
+	FoundationMinRequiredVersion *GaugeDesc
 }
 
-func NewSolanaCollector(rpcClient *rpc.Client, config *ExporterConfig) *SolanaCollector {
+func NewSolanaCollector(rpcClient *rpc.Client, apiClient *api.Client, config *ExporterConfig) *SolanaCollector {
 	collector := &SolanaCollector{
 		rpcClient: rpcClient,
+		apiClient: apiClient,
 		logger:    slog.Get(),
 		config:    config,
 		ValidatorActiveStake: NewGaugeDesc(
@@ -139,6 +144,11 @@ func NewSolanaCollector(rpcClient *rpc.Client, config *ExporterConfig) *SolanaCo
 			fmt.Sprintf("Whether the node is active and participating in consensus (using %s pubkey)", IdentityLabel),
 			IdentityLabel,
 		),
+		FoundationMinRequiredVersion: NewGaugeDesc(
+			"solana_foundation_min_required_version",
+			"Minimum required Solana version for the solana foundation delegation program",
+			"agave_min_version", "firedancer_min_version", ClusterLabel, EpochLabel,
+		),
 	}
 	return collector
 }
@@ -160,6 +170,7 @@ func (c *SolanaCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.NodeMinimumLedgerSlot.Desc
 	ch <- c.NodeFirstAvailableBlock.Desc
 	ch <- c.NodeIsActive.Desc
+	ch <- c.FoundationMinRequiredVersion.Desc
 }
 
 func (c *SolanaCollector) collectVoteAccounts(ctx context.Context, ch chan<- prometheus.Metric) {
@@ -351,6 +362,33 @@ func (c *SolanaCollector) Collect(ch chan<- prometheus.Metric) {
 	c.collectVersion(ctx, ch)
 	c.collectIdentity(ctx, ch)
 	c.collectBalances(ctx, ch)
-
+	c.collectFoundationMinRequiredVersion(ctx, ch)
 	c.logger.Info("=========== END COLLECTION ===========")
+}
+
+func (c *SolanaCollector) collectFoundationMinRequiredVersion(ctx context.Context, ch chan<- prometheus.Metric) {
+	c.logger.Info("Collecting minimum required version...")
+
+	genesisHash, err := c.rpcClient.GetGenesisHash(ctx)
+	if err != nil {
+		c.logger.Errorf("failed to get genesis hash: %v", err)
+		ch <- c.FoundationMinRequiredVersion.NewInvalidMetric(err)
+		return
+	}
+	cluster, err := rpc.GetClusterFromGenesisHash(genesisHash)
+	if err != nil {
+		c.logger.Errorf("failed to determine cluster: %v", err)
+		ch <- c.FoundationMinRequiredVersion.NewInvalidMetric(err)
+		return
+	}
+
+	agaveMinVersion, cluster, epoch, firedancerMinVersion, err := c.apiClient.GetMinRequiredVersion(ctx, cluster)
+	if err != nil {
+		c.logger.Errorf("failed to get min required version: %v", err)
+		ch <- c.FoundationMinRequiredVersion.NewInvalidMetric(err)
+	} else {
+		ch <- c.FoundationMinRequiredVersion.MustNewConstMetric(1, agaveMinVersion, firedancerMinVersion, cluster, fmt.Sprintf("%d", epoch))
+	}
+
+	c.logger.Info("Minimum required version collected.")
 }

--- a/cmd/solana-exporter/collector.go
+++ b/cmd/solana-exporter/collector.go
@@ -155,7 +155,7 @@ func NewSolanaCollector(rpcClient *rpc.Client, apiClient *api.Client, config *Ex
 			"agave_min_version", "firedancer_min_version", ClusterLabel, EpochLabel,
 		),
 		NodeIsOutdated: NewGaugeDesc(
-			"solana_node_outdated",
+			"solana_node_is_outdated",
 			"Whether the node is running a version below the required minimum for Firedancer",
 			IsFiredancerLabel, VersionLabel, "required_version", ClusterLabel,
 		),

--- a/cmd/solana-exporter/collector_test.go
+++ b/cmd/solana-exporter/collector_test.go
@@ -263,7 +263,7 @@ func TestSolanaCollector(t *testing.T) {
 			NewLV(0, StateDelinquent),
 		),
 		collector.NodeVersion.makeCollectionTest(
-			NewLV(1, "v1.0.0"),
+			NewLV(1, "0", "v1.0.0"),
 		),
 		collector.NodeIdentity.makeCollectionTest(
 			NewLV(1, "testIdentity"),

--- a/cmd/solana-exporter/collector_test.go
+++ b/cmd/solana-exporter/collector_test.go
@@ -432,11 +432,11 @@ solana_node_is_outdated{cluster="mainnet-beta",is_firedancer="0",required_versio
 		t.Run(tt.name, func(t *testing.T) {
 			_, client := rpc.NewMockClient(t,
 				map[string]any{
-					"getVersion":            map[string]string{"solana-core": tt.version},
-					"getGenesisHash":        rpc.MainnetGenesisHash,
-					"getHealth":             "ok",
-					"getIdentity":           map[string]string{"identity": "testIdentity"},
-					"minimumLedgerSlot":     0,
+					"getVersion":             map[string]string{"solana-core": tt.version},
+					"getGenesisHash":         rpc.MainnetGenesisHash,
+					"getHealth":              "ok",
+					"getIdentity":            map[string]string{"identity": "testIdentity"},
+					"minimumLedgerSlot":      0,
 					"getFirstAvailableBlock": 0,
 					"getVoteAccounts": map[string]any{
 						"current":    []any{},

--- a/cmd/solana-exporter/collector_test.go
+++ b/cmd/solana-exporter/collector_test.go
@@ -373,9 +373,9 @@ func TestSolanaCollector_NodeIsOutdated(t *testing.T) {
 			agaveVer:      "1.0.0",
 			firedancerVer: "1.0.0",
 			expectedOutput: `
-# HELP solana_node_outdated Whether the node is running a version below the required minimum for Firedancer
-# TYPE solana_node_outdated gauge
-solana_node_outdated{cluster="mainnet-beta",is_firedancer="1",required_version="1.0.0",version="0.9.0"} 1
+# HELP solana_node_is_outdated Whether the node is running a version below the required minimum for Firedancer
+# TYPE solana_node_is_outdated gauge
+solana_node_is_outdated{cluster="mainnet-beta",is_firedancer="1",required_version="1.0.0",version="0.9.0"} 1
 `,
 		},
 		{
@@ -385,9 +385,9 @@ solana_node_outdated{cluster="mainnet-beta",is_firedancer="1",required_version="
 			agaveVer:      "1.0.0",
 			firedancerVer: "1.0.0",
 			expectedOutput: `
-# HELP solana_node_outdated Whether the node is running a version below the required minimum for Firedancer
-# TYPE solana_node_outdated gauge
-solana_node_outdated{cluster="mainnet-beta",is_firedancer="1",required_version="1.0.0",version="1.2.0"} 0
+# HELP solana_node_is_outdated Whether the node is running a version below the required minimum for Firedancer
+# TYPE solana_node_is_outdated gauge
+solana_node_is_outdated{cluster="mainnet-beta",is_firedancer="1",required_version="1.0.0",version="1.2.0"} 0
 `,
 		},
 		{
@@ -397,9 +397,9 @@ solana_node_outdated{cluster="mainnet-beta",is_firedancer="1",required_version="
 			agaveVer:      "1.0.0",
 			firedancerVer: "1.0.0",
 			expectedOutput: `
-# HELP solana_node_outdated Whether the node is running a version below the required minimum for Firedancer
-# TYPE solana_node_outdated gauge
-solana_node_outdated{cluster="mainnet-beta",is_firedancer="0",required_version="1.0.0",version="0.9.0"} 1
+# HELP solana_node_is_outdated Whether the node is running a version below the required minimum for Firedancer
+# TYPE solana_node_is_outdated gauge
+solana_node_is_outdated{cluster="mainnet-beta",is_firedancer="0",required_version="1.0.0",version="0.9.0"} 1
 `,
 		},
 		{
@@ -409,9 +409,9 @@ solana_node_outdated{cluster="mainnet-beta",is_firedancer="0",required_version="
 			agaveVer:      "1.0.0",
 			firedancerVer: "1.0.0",
 			expectedOutput: `
-# HELP solana_node_outdated Whether the node is running a version below the required minimum for Firedancer
-# TYPE solana_node_outdated gauge
-solana_node_outdated{cluster="mainnet-beta",is_firedancer="0",required_version="1.0.0",version="1.2.0"} 0
+# HELP solana_node_is_outdated Whether the node is running a version below the required minimum for Firedancer
+# TYPE solana_node_is_outdated gauge
+solana_node_is_outdated{cluster="mainnet-beta",is_firedancer="0",required_version="1.0.0",version="1.2.0"} 0
 `,
 		},
 		{
@@ -421,9 +421,9 @@ solana_node_outdated{cluster="mainnet-beta",is_firedancer="0",required_version="
 			agaveVer:      "1.0.0",
 			firedancerVer: "2.0.0",
 			expectedOutput: `
-# HELP solana_node_outdated Whether the node is running a version below the required minimum for Firedancer
-# TYPE solana_node_outdated gauge
-solana_node_outdated{cluster="mainnet-beta",is_firedancer="0",required_version="1.0.0",version="1.1.0"} 0
+# HELP solana_node_is_outdated Whether the node is running a version below the required minimum for Firedancer
+# TYPE solana_node_is_outdated gauge
+solana_node_is_outdated{cluster="mainnet-beta",is_firedancer="0",required_version="1.0.0",version="1.1.0"} 0
 `,
 		},
 	}
@@ -456,7 +456,7 @@ solana_node_outdated{cluster="mainnet-beta",is_firedancer="0",required_version="
 			collector := NewSolanaCollector(client, mock.Client, &ExporterConfig{})
 			collector.isFiredancer = tt.isFiredancer
 
-			if err := testutil.CollectAndCompare(collector, strings.NewReader(tt.expectedOutput), "solana_node_outdated"); err != nil {
+			if err := testutil.CollectAndCompare(collector, strings.NewReader(tt.expectedOutput), "solana_node_is_outdated"); err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
 		})

--- a/cmd/solana-exporter/config.go
+++ b/cmd/solana-exporter/config.go
@@ -27,6 +27,7 @@ type (
 		SlotPace                         time.Duration
 		ActiveIdentity                   string
 		EpochCleanupTime                 time.Duration
+		FiredancerMetricsPort            int
 	}
 )
 
@@ -53,6 +54,7 @@ func NewExporterConfig(
 	slotPace time.Duration,
 	activeIdentity string,
 	epochCleanupTime time.Duration,
+	firedancerMetricsPort int,
 ) (*ExporterConfig, error) {
 	logger := slog.Get()
 	logger.Infow(
@@ -69,6 +71,7 @@ func NewExporterConfig(
 		"activeIdentity", activeIdentity,
 		"slotPace", slotPace,
 		"epochCleanupTime", epochCleanupTime,
+		"firedancerMetricsPort", firedancerMetricsPort,
 	)
 	if lightMode {
 		if comprehensiveSlotTracking {
@@ -95,7 +98,7 @@ func NewExporterConfig(
 	// get votekeys from rpc:
 	ctx, cancel := context.WithTimeout(ctx, httpTimeout)
 	defer cancel()
-	client := rpc.NewRPCClient(rpcUrl, httpTimeout)
+	client := rpc.NewRPCClient(rpcUrl, httpTimeout, firedancerMetricsPort)
 	voteKeys, err := GetAssociatedVoteAccounts(ctx, client, rpc.CommitmentFinalized, nodeKeys)
 	if err != nil {
 		return nil, fmt.Errorf("error getting vote accounts: %w", err)
@@ -115,6 +118,7 @@ func NewExporterConfig(
 		SlotPace:                         slotPace,
 		ActiveIdentity:                   activeIdentity,
 		EpochCleanupTime:                 epochCleanupTime,
+		FiredancerMetricsPort:            firedancerMetricsPort,
 	}
 	return &config, nil
 }
@@ -133,6 +137,7 @@ func NewExporterConfigFromCLI(ctx context.Context) (*ExporterConfig, error) {
 		slotPace                         int
 		activeIdentity                   string
 		epochCleanupTime                 int
+		firedancerMetricsPort            int
 	)
 	flag.IntVar(
 		&httpTimeout,
@@ -211,6 +216,12 @@ func NewExporterConfigFromCLI(ctx context.Context) (*ExporterConfig, error) {
 		"",
 		"Validator identity public key that determines if the node is considered active in the 'solana_node_is_active' metric.",
 	)
+	flag.IntVar(
+		&firedancerMetricsPort,
+		"firedancer-metrics-port",
+		7999,
+		"Port number for Firedancer metrics endpoint",
+	)
 	flag.Parse()
 
 	config, err := NewExporterConfig(
@@ -227,6 +238,7 @@ func NewExporterConfigFromCLI(ctx context.Context) (*ExporterConfig, error) {
 		time.Duration(slotPace)*time.Second,
 		activeIdentity,
 		time.Duration(epochCleanupTime)*time.Second,
+		firedancerMetricsPort,
 	)
 	if err != nil {
 		return nil, err

--- a/cmd/solana-exporter/config_test.go
+++ b/cmd/solana-exporter/config_test.go
@@ -26,6 +26,7 @@ func TestNewExporterConfig(t *testing.T) {
 		wantErr                          bool
 		expectedVoteKeys                 []string
 		activeIdentity                   string
+		firedancerMetricsPort            int
 	}{
 		{
 			name:                             "valid configuration",
@@ -43,6 +44,7 @@ func TestNewExporterConfig(t *testing.T) {
 			wantErr:                          false,
 			expectedVoteKeys:                 simulator.Votekeys,
 			activeIdentity:                   simulator.Nodekeys[0],
+			firedancerMetricsPort:            7999,
 		},
 		{
 			name:                             "light mode with incompatible options",
@@ -60,6 +62,7 @@ func TestNewExporterConfig(t *testing.T) {
 			wantErr:                          true,
 			expectedVoteKeys:                 nil,
 			activeIdentity:                   simulator.Nodekeys[0],
+			firedancerMetricsPort:            7999,
 		},
 		{
 			name:                             "empty node keys",
@@ -77,6 +80,7 @@ func TestNewExporterConfig(t *testing.T) {
 			wantErr:                          false,
 			expectedVoteKeys:                 []string{},
 			activeIdentity:                   simulator.Nodekeys[0],
+			firedancerMetricsPort:            7999,
 		},
 	}
 
@@ -96,6 +100,7 @@ func TestNewExporterConfig(t *testing.T) {
 				tt.slotPace,
 				tt.activeIdentity,
 				tt.epochCleanupTime,
+				tt.firedancerMetricsPort,
 			)
 
 			// Check error expectation
@@ -119,6 +124,7 @@ func TestNewExporterConfig(t *testing.T) {
 			assert.Equal(t, tt.epochCleanupTime, config.EpochCleanupTime)
 			assert.Equal(t, tt.monitorBlockSizes, config.MonitorBlockSizes)
 			assert.Equal(t, tt.expectedVoteKeys, config.VoteKeys)
+			assert.Equal(t, tt.firedancerMetricsPort, config.FiredancerMetricsPort)
 		})
 	}
 }

--- a/cmd/solana-exporter/main.go
+++ b/cmd/solana-exporter/main.go
@@ -26,7 +26,7 @@ func main() {
 		)
 	}
 
-	rpcClient := rpc.NewRPCClient(config.RpcUrl, config.HttpTimeout)
+	rpcClient := rpc.NewRPCClient(config.RpcUrl, config.HttpTimeout, config.FiredancerMetricsPort)
 	collector := NewSolanaCollector(rpcClient, config)
 	slotWatcher := NewSlotWatcher(rpcClient, config)
 	ctx, cancel := context.WithCancel(ctx)

--- a/cmd/solana-exporter/main.go
+++ b/cmd/solana-exporter/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/asymmetric-research/solana-exporter/pkg/api"
 	"github.com/asymmetric-research/solana-exporter/pkg/rpc"
 	"github.com/asymmetric-research/solana-exporter/pkg/slog"
 	"github.com/prometheus/client_golang/prometheus"
@@ -28,8 +27,7 @@ func main() {
 	}
 
 	rpcClient := rpc.NewRPCClient(config.RpcUrl, config.HttpTimeout, config.FiredancerMetricsPort)
-	apiClient := api.NewClient()
-	collector := NewSolanaCollector(rpcClient, apiClient, config)
+	collector := NewSolanaCollector(rpcClient, config)
 	slotWatcher := NewSlotWatcher(rpcClient, config)
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()

--- a/cmd/solana-exporter/main.go
+++ b/cmd/solana-exporter/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/asymmetric-research/solana-exporter/pkg/api"
 	"github.com/asymmetric-research/solana-exporter/pkg/rpc"
 	"github.com/asymmetric-research/solana-exporter/pkg/slog"
 	"github.com/prometheus/client_golang/prometheus"
@@ -27,7 +28,8 @@ func main() {
 	}
 
 	rpcClient := rpc.NewRPCClient(config.RpcUrl, config.HttpTimeout, config.FiredancerMetricsPort)
-	collector := NewSolanaCollector(rpcClient, config)
+	apiClient := api.NewClient()
+	collector := NewSolanaCollector(rpcClient, apiClient, config)
 	slotWatcher := NewSlotWatcher(rpcClient, config)
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -1,0 +1,96 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+)
+
+const (
+	// CacheTimeout defines how often to refresh the minimum required version (6 hours)
+	CacheTimeout = 6 * time.Hour
+
+	// SolanaEpochStatsAPI is the base URL for the Solana validators epoch stats API
+	SolanaEpochStatsAPI = "https://api.solana.org/api/epoch/required_versions"
+)
+
+type Client struct {
+	HttpClient http.Client
+	baseURL    string
+	cache      struct {
+		agaveVersion      string
+		firedancerVersion string
+		lastCheck         time.Time
+		epoch             int
+	}
+	mu sync.RWMutex
+	// How often to refresh the cache
+	cacheTimeout time.Duration
+}
+
+func NewClient() *Client {
+	return &Client{
+		HttpClient:   http.Client{},
+		cacheTimeout: CacheTimeout,
+		baseURL:      SolanaEpochStatsAPI,
+	}
+}
+
+func (c *Client) GetMinRequiredVersion(ctx context.Context, cluster string) (string, string, int, string, error) {
+	// Check cache first
+	c.mu.RLock()
+	if !c.cache.lastCheck.IsZero() && time.Since(c.cache.lastCheck) < c.cacheTimeout {
+		version := c.cache.agaveVersion
+		firedancerVersion := c.cache.firedancerVersion
+		epoch := c.cache.epoch
+		c.mu.RUnlock()
+		return version, cluster, epoch, firedancerVersion, nil
+	}
+	c.mu.RUnlock()
+
+	// Make API request
+	url := fmt.Sprintf("%s?cluster=%s", c.baseURL, cluster)
+
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return "", cluster, 0, "", fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := c.HttpClient.Do(req)
+	if err != nil {
+		return "", cluster, 0, "", fmt.Errorf("failed to fetch min required version: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var stats ValidatorEpochStats
+	if err := json.NewDecoder(resp.Body).Decode(&stats); err != nil {
+		return "", cluster, 0, "", fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	// Validate the response
+	if len(stats.Data) == 0 {
+		return "", cluster, 0, "", fmt.Errorf("no data found in response")
+	}
+
+	// Get the first element's agave_min_version and epoch
+	agaveMinVersion := stats.Data[0].AgaveMinVersion
+	if agaveMinVersion == "" {
+		return "", cluster, 0, "", fmt.Errorf("agave_min_version not found in response")
+	}
+
+	firedancerMinVersion := stats.Data[0].FiredancerMinVersion
+	epoch := stats.Data[0].Epoch
+
+	// Update cache
+	c.mu.Lock()
+	c.cache.agaveVersion = agaveMinVersion
+	c.cache.firedancerVersion = firedancerMinVersion
+	c.cache.epoch = epoch
+	c.cache.lastCheck = time.Now()
+	c.mu.Unlock()
+
+	return agaveMinVersion, cluster, epoch, firedancerMinVersion, nil
+}

--- a/pkg/api/client_test.go
+++ b/pkg/api/client_test.go
@@ -7,21 +7,57 @@ import (
 	"testing"
 	"time"
 
+	"github.com/asymmetric-research/solana-exporter/pkg/rpc"
+	"github.com/asymmetric-research/solana-exporter/pkg/slog"
 	"github.com/stretchr/testify/assert"
 )
 
+func init() {
+	slog.Init()
+}
+
 func TestClient_GetMinRequiredVersion(t *testing.T) {
 	tests := []struct {
-		name       string
-		cluster    string
-		mockJSON   string
-		wantErr    bool
-		wantErrMsg string
-		want       string
-		wantEpoch  int
+		name         string
+		cluster      string
+		mockJSON     string
+		currentEpoch int
+		wantErr      bool
+		wantErrMsg   string
+		want         string
+		wantEpoch    int
 	}{
 		{
-			name:    "valid mainnet response",
+			name:    "valid mainnet response with matching epoch",
+			cluster: "mainnet-beta",
+			mockJSON: `{
+				"data": [
+					{
+						"cluster": "mainnet-beta",
+						"epoch": 796,
+						"agave_min_version": "2.2.14",
+						"agave_max_version": null,
+						"firedancer_max_version": null,
+						"firedancer_min_version": "0.503.20214",
+						"inherited_from_prev_epoch": true
+					},
+					{
+						"cluster": "mainnet-beta",
+						"epoch": 797,
+						"agave_min_version": "2.2.15",
+						"agave_max_version": null,
+						"firedancer_max_version": null,
+						"firedancer_min_version": "0.503.20215",
+						"inherited_from_prev_epoch": false
+					}
+				]
+			}`,
+			currentEpoch: 797,
+			want:         "2.2.15",
+			wantEpoch:    797,
+		},
+		{
+			name:    "valid mainnet response with fallback to first entry",
 			cluster: "mainnet-beta",
 			mockJSON: `{
 				"data": [
@@ -36,8 +72,9 @@ func TestClient_GetMinRequiredVersion(t *testing.T) {
 					}
 				]
 			}`,
-			want:      "2.2.14",
-			wantEpoch: 796,
+			currentEpoch: 797,
+			want:         "2.2.14",
+			wantEpoch:    796,
 		},
 		{
 			name:    "valid testnet response",
@@ -55,29 +92,33 @@ func TestClient_GetMinRequiredVersion(t *testing.T) {
 					}
 				]
 			}`,
-			want:      "2.1.6",
-			wantEpoch: 797,
+			currentEpoch: 797,
+			want:         "2.1.6",
+			wantEpoch:    797,
 		},
 		{
-			name:       "invalid json response",
-			cluster:    "mainnet-beta",
-			mockJSON:   `{"invalid": "json"`,
-			wantErr:    true,
-			wantErrMsg: "failed to decode response",
+			name:         "invalid json response",
+			cluster:      "mainnet-beta",
+			mockJSON:     `{"invalid": "json"`,
+			currentEpoch: 797,
+			wantErr:      true,
+			wantErrMsg:   "failed to decode response",
 		},
 		{
-			name:       "empty data array",
-			cluster:    "mainnet-beta",
-			mockJSON:   `{"data": []}`,
-			wantErr:    true,
-			wantErrMsg: "no data found in response",
+			name:         "empty data array",
+			cluster:      "mainnet-beta",
+			mockJSON:     `{"data": []}`,
+			currentEpoch: 797,
+			wantErr:      true,
+			wantErrMsg:   "no data found in response",
 		},
 		{
-			name:       "missing agave_min_version",
-			cluster:    "mainnet-beta",
-			mockJSON:   `{"data": [{"cluster": "mainnet-beta", "epoch": 796}]}`,
-			wantErr:    true,
-			wantErrMsg: "agave_min_version not found in response",
+			name:         "missing agave_min_version",
+			cluster:      "mainnet-beta",
+			mockJSON:     `{"data": [{"cluster": "mainnet-beta", "epoch": 796}]}`,
+			currentEpoch: 797,
+			wantErr:      true,
+			wantErrMsg:   "agave_min_version not found in response",
 		},
 	}
 
@@ -95,12 +136,25 @@ func TestClient_GetMinRequiredVersion(t *testing.T) {
 			}))
 			defer server.Close()
 
+			// Create mock RPC client
+			mockServer, mockRPCClient := rpc.NewMockClient(t,
+				map[string]any{
+					"getEpochInfo": map[string]int{
+						"epoch": tt.currentEpoch,
+					},
+				},
+				nil,
+				nil,
+				nil,
+				nil,
+				nil,
+			)
+			defer mockServer.Close()
+
 			// Create client with test server URL
-			client := &Client{
-				HttpClient:   http.Client{},
-				baseURL:      server.URL + "/api/epoch/required_versions",
-				cacheTimeout: time.Hour,
-			}
+			client := NewClient(mockRPCClient)
+			client.baseURL = server.URL + "/api/epoch/required_versions"
+			client.cacheTimeout = time.Hour
 
 			// Test GetMinRequiredVersion
 			got, gotCluster, gotEpoch, gotFiredancerVersion, err := client.GetMinRequiredVersion(context.Background(), tt.cluster)

--- a/pkg/api/client_test.go
+++ b/pkg/api/client_test.go
@@ -1,0 +1,124 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClient_GetMinRequiredVersion(t *testing.T) {
+	tests := []struct {
+		name       string
+		cluster    string
+		mockJSON   string
+		wantErr    bool
+		wantErrMsg string
+		want       string
+		wantEpoch  int
+	}{
+		{
+			name:    "valid mainnet response",
+			cluster: "mainnet-beta",
+			mockJSON: `{
+				"data": [
+					{
+						"cluster": "mainnet-beta",
+						"epoch": 796,
+						"agave_min_version": "2.2.14",
+						"agave_max_version": null,
+						"firedancer_max_version": null,
+						"firedancer_min_version": "0.503.20214",
+						"inherited_from_prev_epoch": true
+					}
+				]
+			}`,
+			want:      "2.2.14",
+			wantEpoch: 796,
+		},
+		{
+			name:    "valid testnet response",
+			cluster: "testnet",
+			mockJSON: `{
+				"data": [
+					{
+						"cluster": "testnet",
+						"epoch": 797,
+						"agave_min_version": "2.1.6",
+						"agave_max_version": null,
+						"firedancer_max_version": null,
+						"firedancer_min_version": "0.503.20214",
+						"inherited_from_prev_epoch": true
+					}
+				]
+			}`,
+			want:      "2.1.6",
+			wantEpoch: 797,
+		},
+		{
+			name:       "invalid json response",
+			cluster:    "mainnet-beta",
+			mockJSON:   `{"invalid": "json"`,
+			wantErr:    true,
+			wantErrMsg: "failed to decode response",
+		},
+		{
+			name:       "empty data array",
+			cluster:    "mainnet-beta",
+			mockJSON:   `{"data": []}`,
+			wantErr:    true,
+			wantErrMsg: "no data found in response",
+		},
+		{
+			name:       "missing agave_min_version",
+			cluster:    "mainnet-beta",
+			mockJSON:   `{"data": [{"cluster": "mainnet-beta", "epoch": 796}]}`,
+			wantErr:    true,
+			wantErrMsg: "agave_min_version not found in response",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create test server
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// Verify request
+				assert.Equal(t, "/api/epoch/required_versions", r.URL.Path)
+				assert.Equal(t, tt.cluster, r.URL.Query().Get("cluster"))
+
+				// Send response
+				w.Header().Set("Content-Type", "application/json")
+				w.Write([]byte(tt.mockJSON))
+			}))
+			defer server.Close()
+
+			// Create client with test server URL
+			client := &Client{
+				HttpClient:   http.Client{},
+				baseURL:      server.URL + "/api/epoch/required_versions",
+				cacheTimeout: time.Hour,
+			}
+
+			// Test GetMinRequiredVersion
+			got, gotEpoch, err := client.GetMinRequiredVersion(context.Background(), tt.cluster)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrMsg)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.wantEpoch, gotEpoch)
+
+			// Test caching
+			cachedVersion, cachedEpoch, err := client.GetMinRequiredVersion(context.Background(), tt.cluster)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, cachedVersion)
+			assert.Equal(t, tt.wantEpoch, cachedEpoch)
+		})
+	}
+}

--- a/pkg/api/client_test.go
+++ b/pkg/api/client_test.go
@@ -103,7 +103,7 @@ func TestClient_GetMinRequiredVersion(t *testing.T) {
 			}
 
 			// Test GetMinRequiredVersion
-			got, gotEpoch, err := client.GetMinRequiredVersion(context.Background(), tt.cluster)
+			got, gotCluster, gotEpoch, gotFiredancerVersion, err := client.GetMinRequiredVersion(context.Background(), tt.cluster)
 			if tt.wantErr {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErrMsg)
@@ -112,13 +112,17 @@ func TestClient_GetMinRequiredVersion(t *testing.T) {
 
 			assert.NoError(t, err)
 			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.cluster, gotCluster)
 			assert.Equal(t, tt.wantEpoch, gotEpoch)
+			assert.NotEmpty(t, gotFiredancerVersion)
 
 			// Test caching
-			cachedVersion, cachedEpoch, err := client.GetMinRequiredVersion(context.Background(), tt.cluster)
+			cachedVersion, cachedCluster, cachedEpoch, cachedFiredancerVersion, err := client.GetMinRequiredVersion(context.Background(), tt.cluster)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.want, cachedVersion)
+			assert.Equal(t, tt.cluster, cachedCluster)
 			assert.Equal(t, tt.wantEpoch, cachedEpoch)
+			assert.NotEmpty(t, cachedFiredancerVersion)
 		})
 	}
 }

--- a/pkg/api/client_test.go
+++ b/pkg/api/client_test.go
@@ -115,7 +115,7 @@ func TestClient_GetMinRequiredVersion(t *testing.T) {
 		{
 			name:         "missing agave_min_version",
 			cluster:      "mainnet-beta",
-			mockJSON:     `{"data": [{"cluster": "mainnet-beta", "epoch": 796}]}`,
+			mockJSON:     `{"data": [{"cluster": "mainnet-beta", "epoch": 796, "firedancer_min_version": "0.503.20214"}]}`,
 			currentEpoch: 797,
 			wantErr:      true,
 			wantErrMsg:   "agave_min_version not found in response",
@@ -172,6 +172,144 @@ func TestClient_GetMinRequiredVersion(t *testing.T) {
 
 			// Test caching
 			cachedVersion, cachedCluster, cachedEpoch, cachedFiredancerVersion, err := client.GetMinRequiredVersion(context.Background(), tt.cluster)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, cachedVersion)
+			assert.Equal(t, tt.cluster, cachedCluster)
+			assert.Equal(t, tt.wantEpoch, cachedEpoch)
+			assert.NotEmpty(t, cachedFiredancerVersion)
+		})
+	}
+}
+
+func TestClient_GetNextEpochMinRequiredVersion(t *testing.T) {
+	tests := []struct {
+		name         string
+		cluster      string
+		mockJSON     string
+		currentEpoch int
+		wantErr      bool
+		wantErrMsg   string
+		want         string
+		wantEpoch    int
+	}{
+		{
+			name:    "valid mainnet response with next epoch",
+			cluster: "mainnet-beta",
+			mockJSON: `{
+				"data": [
+					{
+						"cluster": "mainnet-beta",
+						"epoch": 796,
+						"agave_min_version": "2.2.14",
+						"agave_max_version": null,
+						"firedancer_max_version": null,
+						"firedancer_min_version": "0.503.20214",
+						"inherited_from_prev_epoch": true
+					},
+					{
+						"cluster": "mainnet-beta",
+						"epoch": 797,
+						"agave_min_version": "2.2.15",
+						"agave_max_version": null,
+						"firedancer_max_version": null,
+						"firedancer_min_version": "0.503.20215",
+						"inherited_from_prev_epoch": false
+					},
+					{
+						"cluster": "mainnet-beta",
+						"epoch": 798,
+						"agave_min_version": "2.2.16",
+						"agave_max_version": null,
+						"firedancer_max_version": null,
+						"firedancer_min_version": "0.503.20216",
+						"inherited_from_prev_epoch": false
+					}
+				]
+			}`,
+			currentEpoch: 797,
+			want:         "2.2.16",
+			wantEpoch:    798,
+		},
+		{
+			name:    "no next epoch available - fallback to current epoch",
+			cluster: "mainnet-beta",
+			mockJSON: `{
+				"data": [
+					{
+						"cluster": "mainnet-beta",
+						"epoch": 797,
+						"agave_min_version": "2.2.15",
+						"agave_max_version": null,
+						"firedancer_max_version": null,
+						"firedancer_min_version": "0.503.20215",
+						"inherited_from_prev_epoch": false
+					}
+				]
+			}`,
+			currentEpoch: 797,
+			want:         "2.2.15",
+			wantEpoch:    797,
+		},
+		{
+			name:         "empty data array",
+			cluster:      "mainnet-beta",
+			mockJSON:     `{"data": []}`,
+			currentEpoch: 797,
+			wantErr:      true,
+			wantErrMsg:   "no data found in response",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create test server
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// Verify request
+				assert.Equal(t, "/api/epoch/required_versions", r.URL.Path)
+				assert.Equal(t, tt.cluster, r.URL.Query().Get("cluster"))
+
+				// Send response
+				w.Header().Set("Content-Type", "application/json")
+				w.Write([]byte(tt.mockJSON))
+			}))
+			defer server.Close()
+
+			// Create mock RPC client
+			mockServer, mockRPCClient := rpc.NewMockClient(t,
+				map[string]any{
+					"getEpochInfo": map[string]int{
+						"epoch": tt.currentEpoch,
+					},
+				},
+				nil,
+				nil,
+				nil,
+				nil,
+				nil,
+			)
+			defer mockServer.Close()
+
+			// Create client with test server URL
+			client := NewClient(mockRPCClient)
+			client.baseURL = server.URL + "/api/epoch/required_versions"
+			client.cacheTimeout = time.Hour
+
+			// Test GetNextEpochMinRequiredVersion
+			got, gotCluster, gotEpoch, gotFiredancerVersion, err := client.GetNextEpochMinRequiredVersion(context.Background(), tt.cluster)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrMsg)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.cluster, gotCluster)
+			assert.Equal(t, tt.wantEpoch, gotEpoch)
+			assert.NotEmpty(t, gotFiredancerVersion)
+
+			// Test caching
+			cachedVersion, cachedCluster, cachedEpoch, cachedFiredancerVersion, err := client.GetNextEpochMinRequiredVersion(context.Background(), tt.cluster)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.want, cachedVersion)
 			assert.Equal(t, tt.cluster, cachedCluster)

--- a/pkg/api/mock.go
+++ b/pkg/api/mock.go
@@ -1,0 +1,32 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"time"
+)
+
+type MockClient struct {
+	*Client
+}
+
+func NewMockClient() *MockClient {
+	mock := &Client{
+		HttpClient:   http.Client{},
+		baseURL:      SolanaEpochStatsAPI,
+		cacheTimeout: CacheTimeout,
+	}
+	return &MockClient{
+		Client: mock,
+	}
+}
+
+func (m *MockClient) SetMinRequiredVersion(version string) {
+	m.cache.agaveVersion = version
+	m.cache.firedancerVersion = "1.0.0"
+	m.cache.lastCheck = time.Now()
+}
+
+func (m *MockClient) GetMinRequiredVersion(ctx context.Context, cluster string) (string, string, int, string, error) {
+	return m.cache.agaveVersion, cluster, 0, m.cache.firedancerVersion, nil
+}

--- a/pkg/api/mock.go
+++ b/pkg/api/mock.go
@@ -21,9 +21,9 @@ func NewMockClient() *MockClient {
 	}
 }
 
-func (m *MockClient) SetMinRequiredVersion(version string) {
-	m.cache.agaveVersion = version
-	m.cache.firedancerVersion = "1.0.0"
+func (m *MockClient) SetMinRequiredVersion(agaveVersion, firedancerVersion string) {
+	m.cache.agaveVersion = agaveVersion
+	m.cache.firedancerVersion = firedancerVersion
 	m.cache.lastCheck = time.Now()
 }
 

--- a/pkg/api/mock.go
+++ b/pkg/api/mock.go
@@ -15,6 +15,15 @@ func NewMockClient() *Client {
 		HttpClient:   http.Client{},
 		baseURL:      SolanaEpochStatsAPI,
 		cacheTimeout: CacheTimeout,
+		cache: struct {
+			agaveVersion          string
+			firedancerVersion     string
+			nextAgaveVersion      string
+			nextFiredancerVersion string
+			lastCheck             time.Time
+			epoch                 int
+			nextEpoch             int
+		}{},
 	}
 	return mock
 }
@@ -26,6 +35,17 @@ func (m *Client) SetMinRequiredVersion(agaveVersion, firedancerVersion string) {
 	m.cache.lastCheck = time.Now()
 }
 
+func (m *Client) SetNextEpochMinRequiredVersion(agaveVersion, firedancerVersion string) {
+	m.cache.nextAgaveVersion = agaveVersion
+	m.cache.nextFiredancerVersion = firedancerVersion
+	m.cache.nextEpoch = 798 // Set next epoch value
+	m.cache.lastCheck = time.Now()
+}
+
 func (m *MockClient) GetMinRequiredVersion(ctx context.Context, cluster string) (string, string, int, string, error) {
-	return m.cache.agaveVersion, cluster, 0, m.cache.firedancerVersion, nil
+	return m.cache.agaveVersion, cluster, m.cache.epoch, m.cache.firedancerVersion, nil
+}
+
+func (m *MockClient) GetNextEpochMinRequiredVersion(ctx context.Context, cluster string) (string, string, int, string, error) {
+	return m.cache.nextAgaveVersion, cluster, m.cache.nextEpoch, m.cache.nextFiredancerVersion, nil
 }

--- a/pkg/api/mock.go
+++ b/pkg/api/mock.go
@@ -10,20 +10,19 @@ type MockClient struct {
 	*Client
 }
 
-func NewMockClient() *MockClient {
+func NewMockClient() *Client {
 	mock := &Client{
 		HttpClient:   http.Client{},
 		baseURL:      SolanaEpochStatsAPI,
 		cacheTimeout: CacheTimeout,
 	}
-	return &MockClient{
-		Client: mock,
-	}
+	return mock
 }
 
-func (m *MockClient) SetMinRequiredVersion(agaveVersion, firedancerVersion string) {
+func (m *Client) SetMinRequiredVersion(agaveVersion, firedancerVersion string) {
 	m.cache.agaveVersion = agaveVersion
 	m.cache.firedancerVersion = firedancerVersion
+	m.cache.epoch = 797 // Set a specific epoch value
 	m.cache.lastCheck = time.Now()
 }
 

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -4,10 +4,10 @@ type ValidatorEpochStats struct {
 	Data []struct {
 		Cluster                string  `json:"cluster"`
 		Epoch                  int     `json:"epoch"`
-		AgaveMinVersion       string  `json:"agave_min_version"`
-		AgaveMaxVersion       *string `json:"agave_max_version"`
-		FiredancerMaxVersion  *string `json:"firedancer_max_version"`
-		FiredancerMinVersion  string  `json:"firedancer_min_version"`
+		AgaveMinVersion        string  `json:"agave_min_version"`
+		AgaveMaxVersion        *string `json:"agave_max_version"`
+		FiredancerMaxVersion   *string `json:"firedancer_max_version"`
+		FiredancerMinVersion   string  `json:"firedancer_min_version"`
 		InheritedFromPrevEpoch bool    `json:"inherited_from_prev_epoch"`
 	} `json:"data"`
 }

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1,0 +1,13 @@
+package api
+
+type ValidatorEpochStats struct {
+	Data []struct {
+		Cluster                string  `json:"cluster"`
+		Epoch                  int     `json:"epoch"`
+		AgaveMinVersion       string  `json:"agave_min_version"`
+		AgaveMaxVersion       *string `json:"agave_max_version"`
+		FiredancerMaxVersion  *string `json:"firedancer_max_version"`
+		FiredancerMinVersion  string  `json:"firedancer_min_version"`
+		InheritedFromPrevEpoch bool    `json:"inherited_from_prev_epoch"`
+	} `json:"data"`
+}

--- a/pkg/rpc/client.go
+++ b/pkg/rpc/client.go
@@ -16,10 +16,10 @@ import (
 
 type (
 	Client struct {
-		HttpClient  http.Client
-		RpcUrl      string
-		HttpTimeout time.Duration
-		logger      *zap.SugaredLogger
+		HttpClient            http.Client
+		RpcUrl                string
+		HttpTimeout           time.Duration
+		logger                *zap.SugaredLogger
 		FiredancerMetricsPort int
 	}
 
@@ -67,11 +67,11 @@ func GetClusterFromGenesisHash(hash string) (string, error) {
 
 func NewRPCClient(rpcAddr string, httpTimeout time.Duration, firedancerMetricsPort int) *Client {
 	return &Client{
-		HttpClient:           http.Client{},
-		RpcUrl:              rpcAddr,
-		HttpTimeout:         httpTimeout,
+		HttpClient:            http.Client{},
+		RpcUrl:                rpcAddr,
+		HttpTimeout:           httpTimeout,
 		FiredancerMetricsPort: firedancerMetricsPort,
-		logger:              slog.Get(),
+		logger:                slog.Get(),
 	}
 }
 

--- a/pkg/rpc/mock.go
+++ b/pkg/rpc/mock.go
@@ -334,6 +334,6 @@ func NewMockClient(
 		}
 	})
 
-	client := NewRPCClient(server.URL(), time.Second)
+	client := NewRPCClient(server.URL(), time.Second, 7999)
 	return server, client
 }


### PR DESCRIPTION
## Summary
In order to get paged if the node's client version is below the required ones (by Solana Foundation Delegation Program) some metrics were added.

## Details
- `solana_node_version` metric updated to include `is_firedancer` label, which will be 1 if the node is running firedancer, and 0 if it is not.
- `solana_foundation_min_required_version` metric added with both clients (agave & firedancer) min required versions by the Solana Foundation delegation program.
- `solana_node_is_outdated` metric added. Will be 1 if the required version is higher than the node's current version.

## Testing
This `solana_exporter` version is currently running on `t-lat-solval-01` (PASSIVE node)

---

**Story:** [NOD-1095](https://xlabs-xyz.atlassian.net/browse/NOD-1095)

**Requested Reviewers:** @XLabs/nodes


[NOD-1095]: https://xlabs-xyz.atlassian.net/browse/NOD-1095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ